### PR TITLE
Fix product insertion

### DIFF
--- a/hive.el
+++ b/hive.el
@@ -52,7 +52,7 @@
 
 ;;;###autoload
 (defun sql-hive (&optional buffer)
-  "Run vsql as an inferior process."
+  "Run hive as an inferior process."
   (interactive "P")
   (sql-product-interactive 'hive buffer))
 

--- a/hive.el
+++ b/hive.el
@@ -56,16 +56,14 @@
   (interactive "P")
   (sql-product-interactive 'hive buffer))
 
-(setq sql-product-alist
-      (cons '(hive
-              :sqli-program sql-hive-program
-              :sqli-options sql-hive-options
-              :sqli-login sql-hive-login-params
-              :sqli-comint-func sql-comint-hive
-              :prompt-regexp "^hive> "
-              :prompt-length 5
-              :prompt-cont-regexp "^    > ")
-            sql-product-alist))
+(sql-add-product 'hive "Hive"
+                 :sqli-program 'sql-hive-program
+                 :sqli-options 'sql-hive-options
+                 :sqli-login 'sql-hive-login-params
+                 :sqli-comint-func 'sql-comint-hive
+                 :prompt-regexp "^hive> "
+                 :prompt-length 5
+                 :prompt-cont-regexp "^    > ")
 
 (provide 'hive)
 


### PR DESCRIPTION
Setting sql-product-alist directly doesn't work correctly - it is not possible to set sql-mode buffer to use the hive product, and therefore it's not possible to bind such buffer to a hive SQLi session.
